### PR TITLE
Add datasheet client and finalize tests

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,6 @@
+import ky, { type KyInstance } from "ky"
+import type { Datasheet } from "@tscircuit/fake-snippets/dist/schema"
+
 export interface TscircuitApiClientParameters {
   baseUrl?: string
   apiKey?: string
@@ -6,6 +9,7 @@ export interface TscircuitApiClientParameters {
 export class TscircuitApiClient {
   private baseUrl: string
   private apiKey?: string
+  private ky: KyInstance
 
   constructor({ baseUrl, apiKey }: TscircuitApiClientParameters) {
     this.baseUrl = baseUrl ?? "https://api.tscircuit.com"
@@ -16,5 +20,30 @@ export class TscircuitApiClient {
         "TSCIRCUIT_API_KEY is not set. Please set it in the environment variables or pass it to the constructor to TscircuitApiClient.",
       )
     }
+
+    this.ky = ky.create({
+      prefixUrl: this.baseUrl,
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      retry: 0,
+    })
+  }
+
+  public datasheets = {
+    create: async ({ chip_name }: { chip_name: string }): Promise<Datasheet> => {
+      const res = await this.ky
+        .post("datasheets/create", { json: { chip_name } })
+        .json<{ datasheet: Datasheet }>()
+      return res.datasheet
+    },
+    get: async ({ datasheet_id }: { datasheet_id: string }): Promise<Datasheet> => {
+      const res = await this.ky
+        .get("datasheets/get", { searchParams: { datasheet_id } })
+        .json<{ datasheet: Datasheet }>()
+      return res.datasheet
+    },
   }
 }
+
+export type { Datasheet }

--- a/tests/datasheets/create.test.ts
+++ b/tests/datasheets/create.test.ts
@@ -1,10 +1,12 @@
 import { test, expect } from "bun:test"
 import { getTestFixture } from "tests/fixtures/getTestFixture"
 
-test("/something/create", async () => {
-  const { client } = getTestFixture()
+test("/datasheets/create", async () => {
+  const { client } = await getTestFixture()
 
-  const createdThing = await client.something.create({})
+  const datasheet = await client.datasheets.create({ chip_name: "TestChip" })
 
-  // expect(createdThing)...
+  expect(datasheet.chip_name).toBe("TestChip")
+  expect(datasheet.pin_information).toBeNull()
+  expect(datasheet.datasheet_pdf_urls).toBeNull()
 })

--- a/tests/datasheets/get.test.ts
+++ b/tests/datasheets/get.test.ts
@@ -1,12 +1,12 @@
 import { test, expect } from "bun:test"
 import { getTestFixture } from "tests/fixtures/getTestFixture"
 
-test("/something/get", async () => {
-  const { client } = getTestFixture()
+test("/datasheets/get", async () => {
+  const { client } = await getTestFixture()
 
-  const createdThing = await client.something.create({})
+  const created = await client.datasheets.create({ chip_name: "Chip" })
 
-  const gottenThing = await client.something.get({ something_id: createdThing.something_id })
+  const gotten = await client.datasheets.get({ datasheet_id: created.datasheet_id })
 
-  // expect(gottenThing)...
+  expect(gotten.datasheet_id).toBe(created.datasheet_id)
 })

--- a/tests/fixtures/getTestFixture.ts
+++ b/tests/fixtures/getTestFixture.ts
@@ -3,13 +3,16 @@ import ky, { type KyInstance } from "ky"
 import { startServer } from "./startServer"
 import { seed as seedDB } from "@tscircuit/fake-snippets"
 import getPort from "get-port"
+import { TscircuitApiClient } from "lib"
 
 interface TestFixture {
   ky: KyInstance
   serverUrl: string
+  client: TscircuitApiClient
 }
 
 export const getTestFixture = async (): Promise<TestFixture> => {
+  process.env.BUN_TEST = "true"
   // Find a free port for the test server
   const port = await getPort()
   const testInstanceId = Math.random().toString(36).substring(2, 15)
@@ -32,6 +35,11 @@ export const getTestFixture = async (): Promise<TestFixture> => {
     retry: 0,
   })
 
+  const client = new TscircuitApiClient({
+    baseUrl: serverUrl,
+    apiKey: "dummy",
+  })
+
   // Cleanup logic
   afterAll(() => {
     server.stop()
@@ -40,5 +48,6 @@ export const getTestFixture = async (): Promise<TestFixture> => {
   return {
     ky: kyInstance,
     serverUrl,
+    client,
   }
 }


### PR DESCRIPTION
## Summary
- implement datasheet create/get API in the client
- bootstrap test fixture with client
- complete datasheet create/get tests

## Testing
- `bun test tests/datasheets/create.test.ts`
- `bun test tests/datasheets/get.test.ts`
- `bun test tests`
- `bun run format` *(fails: Script not found)*

------
https://chatgpt.com/codex/tasks/task_b_6858d864d9ac832e929cac85ee16c467