### PR TITLE
Add compile API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,19 @@ an abbreviated example for the RP2040:
   }
 }
 ```
+
+### Compile code
+
+Compile tscircuit JSX/TSX code into Circuit JSON using `client.compile.compileCode`.
+
+```ts
+const result = await client.compile.compileCode({
+  fs_map: {
+    "user-code.tsx": `export default () => (
+      <resistor name="R1" resistance="1k" />
+    )`,
+  },
+})
+
+console.log(result.circuit_json)
+```

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -10,6 +10,7 @@ export class TscircuitApiClient {
   private baseUrl: string
   private apiKey?: string
   private ky: KyInstance
+  private compileKy: KyInstance
 
   constructor({ baseUrl, apiKey }: TscircuitApiClientParameters) {
     this.baseUrl = baseUrl ?? "https://api.tscircuit.com"
@@ -26,6 +27,11 @@ export class TscircuitApiClient {
       headers: {
         Authorization: `Bearer ${this.apiKey}`,
       },
+      retry: 0,
+    })
+
+    this.compileKy = ky.create({
+      prefixUrl: "https://compile.tscircuit.com/api",
       retry: 0,
     })
   }
@@ -83,6 +89,30 @@ export class TscircuitApiClient {
       }
 
       throw new Error("Timed out waiting for datasheet to be processed")
+    },
+  }
+
+  public compile = {
+    compileCode: async ({
+      fs_map,
+      code,
+    }: {
+      fs_map?: Record<string, string>
+      code?: string
+    }): Promise<{ circuit_json: any; logs: any[] }> => {
+      if (fs_map) {
+        return this.compileKy
+          .post("compile", { json: { fs_map } })
+          .json<{ circuit_json: any; logs: any[] }>()
+      }
+
+      if (code) {
+        return this.compileKy
+          .get("compile", { searchParams: { code } })
+          .json<{ circuit_json: any; logs: any[] }>()
+      }
+
+      throw new Error("Either fs_map or code must be provided")
     },
   }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
 import ky, { type KyInstance } from "ky"
-import type { Datasheet } from "@tscircuit/fake-snippets/dist/schema"
+import type { Datasheet } from "@tscircuit/fake-snippets/schema"
 
 export interface TscircuitApiClientParameters {
   baseUrl?: string

--- a/tests/compile/compileCode.test.ts
+++ b/tests/compile/compileCode.test.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "bun:test"
+import { TscircuitApiClient } from "lib"
+
+test("compile.compileCode", async () => {
+  const client = new TscircuitApiClient({ apiKey: "dummy" })
+
+  const result = await client.compile.compileCode({
+    fs_map: {
+      "index.tsx": `export default () => (
+        <resistor name="R1" resistance="1k" />
+      )`,
+    },
+  })
+
+  expect(Array.isArray(result.circuit_json)).toBe(true)
+  expect(Array.isArray(result.logs)).toBe(true)
+})

--- a/tests/types/fake-snippets-bundle.d.ts
+++ b/tests/types/fake-snippets-bundle.d.ts
@@ -1,0 +1,1 @@
+declare module "@tscircuit/fake-snippets/bundle"


### PR DESCRIPTION
## Summary
- support compiling user code via `client.compile.compileCode`
- document compile usage in README
- test compile code

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_687826a6ae88832e84407885c638db2d